### PR TITLE
logs command

### DIFF
--- a/src/modules/Admin/commands/Logs.js
+++ b/src/modules/Admin/commands/Logs.js
@@ -1,0 +1,88 @@
+const { Command, CommandOptions, CommandPermissions } = require('axoncore');
+const { exec } = require('child_process');
+
+class Logs extends Command {
+  constructor(module) {
+    super(module);
+
+    this.label = 'logs';
+    this.aliases = ['l'];
+
+    this.info = {
+      name: 'logs',
+      description: `Shows the contents of Naga's pm2 logs. Pass \'out\' for .out logs and
+                    'err' or 'error' for .err logs. Omit both arguments to use default values 
+                    (15 for 'lines' and out for 'log type').`,
+      usage: 'logs [number of lines] [log type]',
+    };
+
+    this.options = new CommandOptions(this, {
+      argsMin: 0,
+      cooldown: null,
+      hidden: true,
+    });
+    
+    this.permissions = new CommandPermissions(this, {
+      staff: { needed: this.axon.staff.owners },
+    });
+  }
+
+  /**
+   * Sends the results of the 'exec' command in embeds, up to a maximum of 3.
+   * @param {eris.Message} msg - The message that executed the bot command
+   * @param {String} resultString - The result of the 'exec' command
+   */
+  splitSendResults(msg, resultString) {
+    let splitResult = resultString.match(/[\s\S]{1,1900}[\n\r]/g) || [resultString];
+
+    if(splitResult.length > 2) {
+      if(splitResult.length > 3) {
+        this.sendMessage(msg.channel, `Response too long at ${resultString.length} chars! Latest content of the file will still be shown:`)
+      }
+      splitResult = splitResult.slice(splitResult.length - 3);
+    }
+
+    for(const result of splitResult) {
+      this.sendMessage(msg.channel, {
+        embed: {
+          color: this.utils.getColor('green'),
+          description: `\`\`\`js\n${result}\`\`\``
+        }
+      });
+    }
+  }
+
+  async execute({ msg, args }) {
+    const lines = args[0] || 15;
+
+    if(lines < 5) {
+      return this.sendError(msg.channel, "At least 5 lines have to be provided")
+    }
+
+    if(lines > 200) {
+      return this.sendError(msg.channel, "You can't provide more than 200 lines")
+    }
+
+    const logType = args[1]?.toLowerCase() || "out";
+
+    if(!["out", "err", "error"].includes(logType)) {
+      return this.sendError(msg.channel, "Invald log type");
+    }
+
+    const command = `pm2 logs Naga --raw --nostream --${logType} --lines ${lines}`;
+
+    exec(command, async (err, stdout, stderr) => {
+      if(err) {
+        return this.sendError(msg.channel, err);
+      }
+
+      if(logType === "out") {
+        this.splitSendResults(msg, stdout);
+      } else if(logType === "err" || logType === "error") {
+        this.splitSendResults(msg, stderr);
+      }
+    });
+  }
+}
+
+module.exports = Logs;

--- a/src/modules/Admin/commands/index.js
+++ b/src/modules/Admin/commands/index.js
@@ -10,6 +10,7 @@ module.exports = {
     Exec: require('./Exec'),
     ListAcks: require('./ListAcks'),
     LoadPermissions: require('./LoadPermissions'),
+    Logs: require('./Logs'),
     MigrateTopics: require('./MigrateTopics'),
     Restart: require('./Restart'),
     ScrapeLeaderboard: require('./ScrapeLeaderboard'),


### PR DESCRIPTION
Adds a command that allows developers to see the contents of either the .out file or the .err file. 

The core logic of the 'splitSendResults' method was taken from Eval.js, but redone to work with this command specifically. I wanted to make it a utility method since its logic is used across two files, but I ran into problems getting it to work with both plus it would be out of place in this commit. I may throw it into ExtraUtils sometime in the future so consider its addition here temporary.