### PR TITLE
Archive Command Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "axoncore": "git+https://github.com/sodacova/AxonCore.git",
     "canvas": "^2.9.3",
     "davie-eris-embed": "^1.0.3",
-    "eris": "^0.17.1",
+    "eris": "CaptainM777/eris",
     "esm": "^3.2.25",
     "hastebin": "^0.2.1",
     "imgur": "^2.2.0",

--- a/src/modules/Manager/commands/Archive.js
+++ b/src/modules/Manager/commands/Archive.js
@@ -90,7 +90,11 @@ class Archive extends Command {
 
         let channel = args[0].replace('<#','');
         channel = channel.replace('>', '').toString();
-        channel = this.bot.getChannel(channel);
+        channel = this.bot.getChannel(channel) || await this.bot.getRESTChannel(channel);
+        if (!channel) {
+            msg.channel.createMessage('Invalid channel.')
+            return;
+        }
         const quantity = Math.round(args[1] || MESSAGE_QUANTITY);
 
         try {


### PR DESCRIPTION
Fixed the archive command not working for forum channel threads. I forked soda's fork of Eris (which has support for modals) and added in support for forum channels, since the version of Eris we were using did not have it.