### PR TITLE
Ban Hammers

### DIFF
--- a/src/assets/hammers.json
+++ b/src/assets/hammers.json
@@ -1,78 +1,62 @@
 {
     "123261299864895489": [
-        "https://gfycat.com/accomplishedkindheartedatlanticblackgoby",
-        "https://cdn.discordapp.com/attachments/761932330028892194/872786590768963674/tdhammer.gif",
-        "https://cdn.discordapp.com/attachments/761932330028892194/872791096596508712/tdhammer3.gif",
-        "https://cdn.discordapp.com/attachments/761932330028892194/872791101109571624/tdhammer2.gif",
-        "https://media.discordapp.net/attachments/761932330028892194/1037125756200960192/twohammer.gif"
+        "https://imgur.com/YdVyg9R",
+        "https://imgur.com/LEPdH9N",
+        "https://imgur.com/GgLKyJL",
+        "https://imgur.com/24IEhgh"
     ],
    
 
     "737542058138533950": [
-        "https://media.discordapp.net/attachments/411903716996677639/850043039379882004/minthammer.gif"
+        "https://imgur.com/CmyQDmO"
     ],
 
     "254814547326533632": [
         "http://img.soda.gg/sodabanfinal.gif",
         "http://img.soda.gg/sodahammer2.gif"
     ],
-
-
-    "532290521058508821": [ 
-        "https://media.discordapp.net/attachments/776054378993549313/849374016107315240/phantom3.gif",
-        "https://media.discordapp.net/attachments/776054378993549313/849374042196410418/phantom1.gif",
-        "https://cdn.discordapp.com/attachments/830427148488933406/887379114942685274/phants_claire_banhammer.gif",
-        "https://imgur.com/vhAia5L",
-        "https://imgur.com/UuJJv99"
-    ],
+    
     "222634331384840193": [
-        "https://gfycat.com/rigidinsistentindianpalmsquirrel",
-        "https://cdn.discordapp.com/attachments/761932330028892194/938526857840713728/Kratoshammer1.gif",
-        "https://cdn.discordapp.com/attachments/761932330028892194/937866919674015744/63gaod.gif"
-    ],
-
-    "432156129603354624": [
-        "https://media.discordapp.net/attachments/892407163954286592/982622936907284520/bonzuhammer.gif"
+        "https://imgur.com/zGw7lks",
+        "https://imgur.com/JYgjudV"
     ],
 
     "890752824609230959": [
-        "https://media.discordapp.net/attachments/761932330028892194/1078982695905927229/Breadhammer.gif"
+        "https://imgur.com/Hz2hH7i"
     ],
 
-    "231342149847744512": [
-        "https://media.discordapp.net/attachments/411903716996677639/1017868926891348028/Kidehammer.gif"
-    ],
     "510193587430883328": [
-        "https://cdn.discordapp.com/attachments/831909387307319336/1073106997999837224/trim.41B64A17-E221-4DDA-8EFF-8343F2DCC7FD.gif",
-        "https://cdn.discordapp.com/attachments/411903716996677639/1086045579513176235/trim.90AED007-E932-43FF-A53C-1FFF0C4402B0.gif",
-        "https://cdn.discordapp.com/attachments/411903716996677639/1086044824366489660/trim.1D24992E-9BEE-4395-B1C0-C1BCD4B4166C.gif",
-        "https://cdn.discordapp.com/attachments/411903716996677639/1086044812924432556/trim.E9A49573-CC4C-4A92-BACB-53F7440C956D.gif",
-        "https://media.discordapp.net/attachments/831909387307319336/1073106981050654780/trim.17073303-B5BD-4EBA-9F6B-E84136CF81B0.gif",
-        "https://cdn.discordapp.com/attachments/411903716996677639/1086042986846101646/trim.28E8BF85-C9F5-4A9A-8B06-6FBA3B9BDCDB.gif",
-        "https://cdn.discordapp.com/attachments/411903716996677639/1086042256894611638/trim.C224C090-104E-4330-BD4F-ADCE4CCAD0F9.gif;"
+        "https://imgur.com/50NqGe7",
+        "https://imgur.com/QQUQCBc",
+        "https://imgur.com/LFMSWeI",
+        "https://imgur.com/zy8sQeI",
+        "https://imgur.com/frthlgZ",
+        "https://imgur.com/5aqyMJX",
+        "https://imgur.com/fBGEo8n"
     ],
+
     "681334177928577066": [
-        "https://cdn.discordapp.com/attachments/761932330028892194/872651158513135666/TifaAC_on_the_attack.gif",
-        "https://cdn.discordapp.com/attachments/761932330028892194/872651443683872838/Homura_rockets.gif",
-        "https://cdn.discordapp.com/attachments/761932330028892194/872778141968510976/razor_crest.gif"
-    ],
-    "283451169152696320": [
-        "https://gfycat.com/obedientdamparthropods"
+        "https://imgur.com/BitL88A",
+        "https://imgur.com/uuLlhdE",
+        "https://imgur.com/l2wZdAe"
     ],
 
     "791269922617556995": [
         "https://media.giphy.com/media/NlZbKCWCXhTlz4GczR/giphy-downsized-large.gif"
     ],
+
     "1144231168242368532" : [
         "https://www.icegif.com/wp-content/uploads/2023/03/icegif-1632.gif"
     ], 
+
     "995668136672116746" : [
-        "https://cdn.discordapp.com/attachments/995676977258299432/1251610508503814195/PhoebeHammer4.gif?ex=66747a9f&is=6673291f&hm=e3d522fb1b920fb2975fd903ebc84e22aa90527b271807b1de3e95c9c6b2681d&",
-        "https://media.discordapp.net/attachments/995676977258299432/1251610508944212110/PhoebeHammer3.gif?ex=66747a9f&is=6673291f&hm=d16409e2bd95205a260d78aa3e8abcc8ecc7b8a3f0d3b26db50f91ee214c0e17&=",
-        "https://cdn.discordapp.com/attachments/995676977258299432/1251610509485281331/PhoebeHammer2.gif?ex=66747a9f&is=6673291f&hm=35110fc9dc8ae0885cfdda11c04e05e4f8e461c1297425ceccb21fc331ba89de&",
-        "https://cdn.discordapp.com/attachments/995676977258299432/1251610509866827806/PhoebeHammer1-ezgif.com-video-to-gif-converter.gif?ex=66747a9f&is=6673291f&hm=6b4e675a147f662e87a08851dcbd1b501840f856adfa951ab122c110cd4ecb19&"
+        "https://imgur.com/IaBN8WN",
+        "https://imgur.com/mf6ogef",
+        "https://imgur.com/mLhSCxR",
+        "https://imgur.com/bXfXNF5"
     ], 
+
     "416630867209748483" : [
-        "https://cdn.discordapp.com/attachments/761932330028892194/1225155557384523887/muhi_lannisterr.gif"
+        "https://imgur.com/Gs4whuu"
     ]
 }


### PR DESCRIPTION
This closes #262. 
- Replaced dead Discord cdn/media links with Imgur ones 
- Removed dead non-Discord links, to be re-added with working ones at a later date
- Removed the ban hammers of former staff