### PR TITLE
Autocontext Fixes

### DIFF
--- a/src/modules/Events/Misc/AutoContext.js
+++ b/src/modules/Events/Misc/AutoContext.js
@@ -1,12 +1,18 @@
 const { Listener } = require('axoncore');
+const Eris = require('eris');
 
-const ALLOWED_CATEGORIES = [
+const SHARED_STAFF_CATEGORIES = [
     '372085914765099008', // Moderation
     '372088029495689226', // Logs
-    '828540781291241492', // Garden Gate
-    '719883529470738523', // Lake Laogai
     '1039274712905298062' // Community
 ];
+
+const UPPER_STAFF_CATEGORIES = [
+    '828540781291241492', // Garden Gate
+    '719883529470738523', // Lake Laogai
+];
+
+const ALLOWED_CATEGORIES = [ ...SHARED_STAFF_CATEGORIES, ...UPPER_STAFF_CATEGORIES ];
 
 const MESSAGE_LINK_REGEX = /https:\/\/(?:canary|ptb)?\.?discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/
 
@@ -26,11 +32,27 @@ class AutoContext extends Listener {
     }
 
     /**
+     * Gets the category ID of a given channel. If the channel is a thread, the parent text channel's category ID is retrieved.
+     * @param {eris.Channel} channel - The channel to be evaluated
+     * @param {String} categoryID - The category ID
+     */
+    getCategoryID(channel) {
+        let categoryID = channel.parentID;
+        if (channel instanceof Eris.PublicThreadChannel || channel instanceof Eris.PrivateThreadChannel) {
+            let parentTextChannel = this.bot.getChannel(categoryID);
+            categoryID = parentTextChannel.parentID;
+        }
+        return categoryID;
+    }
+
+    /**
      * @param {import('eris').Message} msg
      */
     async execute(msg) { // eslint-disable-line
         if (msg.author.bot) return;
-        if (!ALLOWED_CATEGORIES.includes(msg.channel.parentID)) return;
+
+        let parentID = this.getCategoryID(msg.channel);
+        if (!ALLOWED_CATEGORIES.includes(parentID)) return;
 
         let msgLink = msg.content.match(MESSAGE_LINK_REGEX);
         if (!msgLink) return;
@@ -40,11 +62,14 @@ class AutoContext extends Listener {
 
         let quantity = 5;
 
-        let embed, message = await this.bot.getMessage(channelID, messageID);
-        if (UPPER_STAFF_CATEGORIES.includes(message.channel.parentID)) return; 
+        let embed, linkedMessage = await this.bot.getMessage(channelID, messageID);
+        let linkedMessageCategoryID = this.getCategoryID(linkedMessage.channel);
 
-        if (message.embeds.length && (ALLOWED_CATEGORIES.includes(message.channel.parentID)) || message.channel.id === '372098279615496192') {
-            embed = message.embeds[0]; // Ssend embed for bot messages sent in log channels or #avatar-feeds without additional context
+        // Prevent links from upper staff categories from embedding in shared staff categories
+        if (UPPER_STAFF_CATEGORIES.includes(linkedMessageCategoryID) && SHARED_STAFF_CATEGORIES.includes(parentID)) return; 
+
+        if (linkedMessage.embeds.length && (ALLOWED_CATEGORIES.includes(linkedMessageCategoryID)) || linkedMessage.channel.id === '372098279615496192') {
+            embed = linkedMessage.embeds[0]; // Send embed for bot messages sent in log channels or #avatar-feeds without additional context
         } else {
             let oldMessages;
             await this.bot.getMessages(channelID, { before: messageID, limit: quantity })
@@ -54,21 +79,21 @@ class AutoContext extends Listener {
                 })
                 oldMessages = messages.reverse();
             });
-            oldMessages.push(`__**${this.utils.fullName(message.author)} (<t:${Math.floor(message.createdAt / 1000)}:R>)  -  ${message.content}**__`);
+            oldMessages.push(`__**${this.utils.fullName(linkedMessage.author)} (<t:${Math.floor(linkedMessage.createdAt / 1000)}:R>)  -  ${linkedMessage.content}**__`);
             let msgContent = oldMessages.join('\n');
             embed = {
                 color: this.utils.getColor('blue'),
                 author: { 
-                    name: `Messages sent in #${message.channel.name}`,
+                    name: `Messages sent in #${linkedMessage.channel.name}`,
                     icon_url: msg.channel.guild.iconURL
                 },
                 description: `${msgContent}`,
-                footer: { text: `Message ID: ${message.id} | Author ID: ${message.author.id}` },
-                timestamp: message.createdAt
+                footer: { text: `Message ID: ${linkedMessage.id} | Author ID: ${linkedMessage.author.id}` },
+                timestamp: new Date(linkedMessage.createdAt).toISOString()
             }
 
-            if (message.attachments.length > 0) {
-                embed.image = { url: message.attachments[0].url };
+            if (linkedMessage.attachments.length > 0) {
+                embed.image = { url: linkedMessage.attachments[0].url };
             }
         }
 

--- a/src/modules/Events/Misc/AutoContext.js
+++ b/src/modules/Events/Misc/AutoContext.js
@@ -17,6 +17,12 @@ const ADMIN_CHANNELS = [
     '1108139717955944488', // internal-changelog
 ]
 
+const MOVER_STARS_CHANNELS = [
+    '1032450052112793700', // mover-stars
+    '1049810187650879498', // partners-chat
+    '869740603557158973', // wiki
+]
+
 const ALLOWED_CATEGORIES = [ ...SHARED_STAFF_CATEGORIES, ...UPPER_STAFF_CATEGORIES ];
 
 const MESSAGE_LINK_REGEX = /https:\/\/(?:canary|ptb)?\.?discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/
@@ -68,10 +74,26 @@ class AutoContext extends Listener {
         let quantity = 5;
 
         let embed, linkedMessage = await this.bot.getMessage(channelID, messageID);
-        let linkedMessageCategoryID = this.getCategoryID(linkedMessage.channel);
+        if (linkedMessage.channel instanceof Eris.PrivateThreadChannel) return;
 
-        // Links from admin channels and threads can only embed in admin channels
-        if ((ADMIN_CHANNELS.includes(linkedMessage.channel.id) || ADMIN_CHANNELS.includes(linkedMessage.parentID)) && !ADMIN_CHANNELS.includes(msg.channel.id)) return;
+        // Links from admin channels and threads can only embed in those same places
+        if (
+            (ADMIN_CHANNELS.includes(linkedMessage.channel.id) || ADMIN_CHANNELS.includes(linkedMessage.channel.parentID)) && 
+            (!ADMIN_CHANNELS.includes(msg.channel.id) && !ADMIN_CHANNELS.includes(msg.channel.parentID))
+        ) {
+           return;
+        }
+
+        // Links from Mover Stars channels and threads can only embed in those same places
+        if (
+            (MOVER_STARS_CHANNELS.includes(linkedMessage.channel.id) || MOVER_STARS_CHANNELS.includes(linkedMessage.channel.parentID)) && 
+            (!MOVER_STARS_CHANNELS.includes(msg.channel.id) && !MOVER_STARS_CHANNELS.includes(msg.channel.parentID)) &&
+            (!ADMIN_CHANNELS.includes(msg.channel.id) && !ADMIN_CHANNELS.includes(msg.channel.parentID))
+        ) {
+           return;
+        }
+
+        let linkedMessageCategoryID = this.getCategoryID(linkedMessage.channel);
 
         // Prevent links from upper staff categories from embedding in shared staff categories
         if (UPPER_STAFF_CATEGORIES.includes(linkedMessageCategoryID) && SHARED_STAFF_CATEGORIES.includes(parentID)) return;

--- a/src/modules/Events/Misc/AutoContext.js
+++ b/src/modules/Events/Misc/AutoContext.js
@@ -12,6 +12,11 @@ const UPPER_STAFF_CATEGORIES = [
     '719883529470738523', // Lake Laogai
 ];
 
+const ADMIN_CHANNELS = [
+    '370708369951948802', // old-people-camp
+    '1108139717955944488', // internal-changelog
+]
+
 const ALLOWED_CATEGORIES = [ ...SHARED_STAFF_CATEGORIES, ...UPPER_STAFF_CATEGORIES ];
 
 const MESSAGE_LINK_REGEX = /https:\/\/(?:canary|ptb)?\.?discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/
@@ -65,8 +70,14 @@ class AutoContext extends Listener {
         let embed, linkedMessage = await this.bot.getMessage(channelID, messageID);
         let linkedMessageCategoryID = this.getCategoryID(linkedMessage.channel);
 
+        // Links from admin channels and threads can only embed in admin channels
+        if ((ADMIN_CHANNELS.includes(linkedMessage.channel.id) || ADMIN_CHANNELS.includes(linkedMessage.parentID)) && !ADMIN_CHANNELS.includes(msg.channel.id)) return;
+
         // Prevent links from upper staff categories from embedding in shared staff categories
-        if (UPPER_STAFF_CATEGORIES.includes(linkedMessageCategoryID) && SHARED_STAFF_CATEGORIES.includes(parentID)) return; 
+        if (UPPER_STAFF_CATEGORIES.includes(linkedMessageCategoryID) && SHARED_STAFF_CATEGORIES.includes(parentID)) return;
+
+        // Prevent links from the Moderation and Logs categories from embedding in the Community category
+        if ((linkedMessageCategoryID === '372085914765099008' || linkedMessageCategoryID === '372088029495689226') && parentID === '1039274712905298062') return;
 
         if (linkedMessage.embeds.length && (ALLOWED_CATEGORIES.includes(linkedMessageCategoryID)) || linkedMessage.channel.id === '372098279615496192') {
             embed = linkedMessage.embeds[0]; // Send embed for bot messages sent in log channels or #avatar-feeds without additional context


### PR DESCRIPTION
- Fixed incorrect embed timestamp format
- Added embed safeguards
  - Links from upper staff categories (Garden Gate, Lake Laogai) will not embed in shared staff categories (Moderation, Logs, Community)
  - Links from the Moderation and Logs category will not embed in the Community category
  - Links from private threads will not embed anywhere
  - Links from admin channels and public threads will only embed in those same places
  - Links from Mover Stars channels and public threads will only embed in those places as well as admin channels and threads
- I know some of the if statement conditions are ugly, I might refactor these at a later date but this is the best I could do for now